### PR TITLE
会員登録画面１ページ目作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,30 +23,37 @@ gem 'slim-rails'
 
 gem 'html2slim'
 # html.erbをhtmle.slimに変換するためのgem
+
 gem 'devise'
 
 gem 'devise-i18n'
 gem 'devise-i18n-views'
 gem 'rails-i18n'
-#deviseを日本語化、またviewをカスタマイズする際に、devise-i18nは適用されないので、通常のi18nを追加
+# deviseを日本語化、またviewをカスタマイズする際に、devise-i18nは適用されないので、通常のi18nを追加
 
-# Seeds
+# 初期データを登録
 gem 'seed-fu'
 
-# Pagination
-# gem 'bootstrap4-kaminari-views'
+# ページネーションを実装
 gem 'kaminari'
 gem 'kaminari-i18n'
+# お洒落なページネーションを実装可能
+# gem 'bootstrap4-kaminari-views'
 
-# Breadcrumbs
+# パンくずリストを実装
+# パンくずリストとはユーザーに今自分がサイトのどの位置にいるかをわかりやすくするためのリスト
 gem 'gretel'
 
 # image uploader
+# ImageMagickをrailsで扱えるようにしてくれるGem
 gem 'mini_magick'
+
+# MiniMagickで提供できない画像サイズを調整する機能
 gem "image_processing", "~> 1.0"
 
-# gem for search
+# 検索機能実装
 gem 'ransack'
+
 
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
@@ -57,11 +64,11 @@ gem 'ransack'
 # gem 'image_processing', '~> 1.2'
 
 # Reduces boot times through caching; required in config/boot.rb
-gem 'bootsnap', '>= 1.4.4', require: false
+gem 'bootsnap', '>= 1.4.4', require: false # デフォルトで記載
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw] # デフォルトで記載
   # rspecにてあらかじめ作っておきたいデータを格納
   gem 'factory_bot_rails'
   # ダミーデータをデータベースに作成する。
@@ -80,7 +87,7 @@ group :development, :test do
   gem 'letter_opener_web'
 end
 
-group :development do
+group :development do # デフォルトで記載
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'web-console', '>= 4.1.0'
   # Display performance information such as SQL time and flame graphs for each request in your browser.
@@ -91,13 +98,12 @@ group :development do
   gem 'spring'
 end
 
-group :test do
+group :test do # デフォルトで記載
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '>= 3.26'
-  gem 'selenium-webdriver'
   # Easy installation and use of web drivers to run system tests with browsers
   gem 'webdrivers'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby] # デフォルトで記載

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,4 +13,4 @@
  *= require_tree .
  *= require_self
  */
- @import "reset";
+@import "reset";

--- a/app/assets/stylesheets/comon.scss
+++ b/app/assets/stylesheets/comon.scss
@@ -10,8 +10,20 @@ $color-bubble: linear-gradient(to bottom, rgba(198, 168, 237, 0.237) 0%, rgba(58
   left: $left;
   z-index: 0;
 }
+@mixin btn($btn-color, $color){
+  border: 1px solid $btn-color;
+  border-radius: 20px;
+  background-color: $btn-color;
+  width: 150px;
+  margin: 30px auto;
+  padding: 10px 20px;
+  color: $color;
+}
+.submit-btn{
+  @include btn(lime, black);
+}
 .page-container{
-  text-align: center;
+  text-align: center;//ページの大枠を囲む
 }
 .page-pink-wrap{
   background-color: $color-pink;
@@ -22,9 +34,11 @@ $color-bubble: linear-gradient(to bottom, rgba(198, 168, 237, 0.237) 0%, rgba(58
   width: 60%;
   min-width: 500px;
 }
+
 .small-color-bubble{
   @include color-bubble;
-}
+}//小さいシャボン玉
+
 .big-color-bubble{
   @include color-bubble(480px, -200px, 1000px);
-}
+}//大きいシャボン玉

--- a/app/assets/stylesheets/sign_in.scss
+++ b/app/assets/stylesheets/sign_in.scss
@@ -1,16 +1,5 @@
-@mixin btn($btn-color, $color){
-  border: 1px solid $btn-color;
-  border-radius: 20px;
-  background-color: $btn-color;
-  width: 150px;
-  margin: 30px auto;
-  padding: 10px 20px;
-  color: $color;
-}
-.submit-btn{
-  @include btn(lime, black);
-}
 .sign_in{
   font-family: cursive;
   font-size: 28px;
+  margin-top: 30px;
 }

--- a/app/assets/stylesheets/sign_in.scss
+++ b/app/assets/stylesheets/sign_in.scss
@@ -1,15 +1,14 @@
-@mixin btn($btn-color){
+@mixin btn($btn-color, $color){
   border: 1px solid $btn-color;
-  border-radius: 30px;
+  border-radius: 20px;
   background-color: $btn-color;
   width: 150px;
   margin: 30px auto;
-  padding: 10px 0;
-  color: #fff;
+  padding: 10px 20px;
+  color: $color;
 }
 .submit-btn{
-  @include btn(aqua);
-  color: black;
+  @include btn(lime, black);
 }
 .sign_in{
   font-family: cursive;

--- a/app/assets/stylesheets/sing_up.scss
+++ b/app/assets/stylesheets/sing_up.scss
@@ -1,0 +1,12 @@
+.form_label{
+  display: block;
+  margin-top: 30px;
+}
+.form_field{
+  width: 350px;
+  border: solid 1px #fff;
+  background-color: #fff;
+  text-align: center;
+  border-radius: 10px;
+  padding: 5px;
+}

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the users controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -9,6 +9,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
+  def step1
+    @user = User.new(sign_up_params)
+  end
+
   # POST /resource
   # def create
   #   super

--- a/app/views/homes/index.html.slim
+++ b/app/views/homes/index.html.slim
@@ -4,5 +4,3 @@ div.page-container
     p.App-name-heading ITの人との出会いをもっと身近に
     div.login-btn = link_to 'ログイン', new_user_session_path
     div.signup-btn = link_to '会員登録', new_user_registration_path
-div.small-color-bubble
-div.big-color-bubble

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -12,5 +12,7 @@ html
     p.notice = notice
     p.alert = alert  
     = render 'layouts/header'
+    div.small-color-bubble
+    div.big-color-bubble
     = yield
     = debug(params) if Rails.env.development?

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -1,27 +1,26 @@
 div.page-container
   div.page-pink-wrap
+    //このコード分からなかったです
     h2.sign_in = (t 'users.registrations.new.sign_up')
-    = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+    = form_with(url: users_sign_up_step2_path, local: true) do |f|
       = render "users/shared/error_messages", resource: resource
-      .field
-        = f.label :email
+      div.input_field
+        = f.label :email, 'メールアドレス'
         br
         = f.email_field :email, autofocus: true, autocomplete: "email"
-      .field
-        = f.label :password
-        - if @minimum_password_length
-          em
-            | (
-            = @minimum_password_length
-            |  文字以上)
+      div.input_field
+        = f.label :password, 'パスワード'
+        br
+        em （半角大文字小文字数字を１文字以上含んでください）
         br
         = f.password_field :password, autocomplete: "new-password"
-      .field
-        = f.label :password_confirmation
+      div.input_field
+        = f.label :password_confirmation, 'パスワード（確認）'
         br
         = f.password_field :password_confirmation, autocomplete: "new-password"
       .actions
-        = f.submit (t 'users.registrations.new.sign_up'), class: 'submit-btn'
-    = render "users/shared/links"
-div.small-color-bubble
-div.big-color-bubble
+        //このコード分からなかったです
+        /= f.submit (t 'users.registrations.new.sign_up'), class: 'submit-btn'
+        = f.submit ('次へ'), class: 'submit-btn'
+    //このコード分からなかったです
+    /= render "users/shared/links"

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -5,19 +5,19 @@ div.page-container
     = form_with(url: users_sign_up_step2_path, local: true) do |f|
       = render "users/shared/error_messages", resource: resource
       div.input_field
-        = f.label :email, 'メールアドレス'
+        = f.label :email, 'メールアドレス', class: 'form_label'
         br
-        = f.email_field :email, autofocus: true, autocomplete: "email"
+        = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form_field', required:'required'
       div.input_field
-        = f.label :password, 'パスワード'
+        = f.label :password, 'パスワード', class: 'form_label'
         br
         em （半角大文字小文字数字を１文字以上含んでください）
         br
-        = f.password_field :password, autocomplete: "new-password"
+        = f.password_field :password, autocomplete: 'new-password', class: 'form_field', required:'required'
       div.input_field
-        = f.label :password_confirmation, 'パスワード（確認）'
+        = f.label :password_confirmation, 'パスワード（確認）', class: 'form_label'
         br
-        = f.password_field :password_confirmation, autocomplete: "new-password"
+        = f.password_field :password_confirmation, autocomplete: 'new-password', class: 'form_field', required:'required'
       .actions
         //このコード分からなかったです
         /= f.submit (t 'users.registrations.new.sign_up'), class: 'submit-btn'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,15 @@
 Rails.application.routes.draw do
+  root 'homes#index'
   devise_for :users, controllers: {
     registrations: 'users/registrations',
-    sessions: 'users/sessions',
-    confirmations: 'users/confirmations',
-    passwords: 'users/passwords'
+    sessions: 'users/sessions'
   }
-  root 'homes#index'
+
+  devise_scope :user do
+    get 'users/sign_up/step2', to: 'users/registrations#step2'
+    get 'users/sign_up/step3', to: 'users/registrations#step3'
+    get 'users/login', to: 'users/sessions#new'
+    post 'users/login', to: 'users/sessions#create'
+    delete 'users/logout', to: 'users/sessions#destroy'
+  end
 end


### PR DESCRIPTION
- gemfileのgemの説明記載
gemの種類が分からなかったため

- bubbleをaplication.slimに記載
どのページでも表示される為共通化しました。

- 会員登録画面の１ページ目を作成
デバイスの標準のviewだと見にくいため

- ルーティングを追加
デバイスのコントローラーをカスタマイズする為
またルーティングをカスタマイズしてURLを分かりやすくした。

- comon.scssに@mixinを使ってボタンを定義した
共通のscssに@mixinで定義したボタンを書きました。

_before_
<img width="1000" alt="スクリーンショット 2022-03-23 15 14 41" src="https://user-images.githubusercontent.com/85437356/159965504-bb534040-5ff7-49eb-b40f-7fe60b120fa3.png">

_after_
<img width="1000" alt="スクリーンショット 2022-03-25 1 31 37" src="https://user-images.githubusercontent.com/85437356/159965633-e0503140-094f-4f71-adb0-09417682f7ec.png">

