### PR TITLE
会員登録画面１ページ目修正

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -19,6 +19,18 @@ $color-bubble: linear-gradient(to bottom, rgba(198, 168, 237, 0.237) 0%, rgba(58
   padding: 10px 20px;
   color: $color;
 }
+.signup-btn{
+  @include btn(lime, black);
+  a{
+    text-decoration: none;
+  }
+}
+.login-btn{
+  @include btn(aqua, black);
+  a{
+    text-decoration: none;
+  }
+}
 .submit-btn{
   @include btn(lime, black);
 }

--- a/app/assets/stylesheets/homes.scss
+++ b/app/assets/stylesheets/homes.scss
@@ -1,12 +1,3 @@
-@mixin btn($btn-color){
-  border: 1px solid $btn-color;
-  border-radius: 30px;
-  background-color: $btn-color;
-  width: 150px;
-  margin: 30px auto;
-  padding: 10px 0;
-  color: #fff;
-}
 .App-name{
   font-family: cursive;
   font-size: 28px;
@@ -15,9 +6,4 @@
   font-size: 18px;
   margin-bottom: 200px;
 }
-.signup-btn{
-  @include btn(lime);
-}
-.login-btn{
-  @include btn(aqua);
-}
+

--- a/app/assets/stylesheets/sign_in.scss
+++ b/app/assets/stylesheets/sign_in.scss
@@ -1,5 +1,0 @@
-.sign_in{
-  font-family: cursive;
-  font-size: 28px;
-  margin-top: 30px;
-}

--- a/app/assets/stylesheets/user.scss
+++ b/app/assets/stylesheets/user.scss
@@ -1,12 +1,17 @@
 .form_label{
   display: block;
-  margin-top: 30px;
+  margin: 30px 0 10px 0;
 }
 .form_field{
   width: 350px;
-  border: solid 1px #fff;
+  border: solid 1px;
   background-color: #fff;
   text-align: center;
   border-radius: 10px;
   padding: 5px;
+}
+.sign_in{
+  font-family: cursive;
+  font-size: 28px;
+  margin-top: 30px;
 }

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -1,9 +1,9 @@
 header.header-container
   nav
     ul.header-items-container
-      li.header-logo = link_to "Moteic", "#"
+      li.header-logo = link_to "Moteic", root_path
       div.header-items-container
         li.header-items = link_to "利用規約", "#"
         li.header-items = link_to "初めての方", "#"
-        li.header-items = link_to "ログイン", "#"
-        li.header-items = link_to "新規登録", "#"
+        li.header-items = link_to "ログイン", new_user_session_path
+        li.header-items = link_to "新規登録", new_user_registration_path

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -4,23 +4,19 @@ div.page-container
     h2.sign_in = (t 'users.registrations.new.sign_up')
     = form_with(url: users_sign_up_step2_path, local: true) do |f|
       = render "users/shared/error_messages", resource: resource
-      div.input_field
-        = f.label :email, 'メールアドレス', class: 'form_label'
-        br
-        = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form_field', required:'required'
-      div.input_field
-        = f.label :password, 'パスワード', class: 'form_label'
-        br
-        em （半角大文字小文字数字を１文字以上含んでください）
-        br
-        = f.password_field :password, autocomplete: 'new-password', class: 'form_field', required:'required'
-      div.input_field
-        = f.label :password_confirmation, 'パスワード（確認）', class: 'form_label'
-        br
-        = f.password_field :password_confirmation, autocomplete: 'new-password', class: 'form_field', required:'required'
+      = f.label :email, 'メールアドレス', class: 'form_label'
+      = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form_field', required:'required'
+
+      = f.label :password, 'パスワード', class: 'form_label'
+      em （半角大文字小文字数字を１文字以上含んでください）
+      br
+      = f.password_field :password, autocomplete: 'new-password', class: 'form_field', required:'required'
+
+      = f.label :password_confirmation, 'パスワード（確認）', class: 'form_label'
+      = f.password_field :password_confirmation, autocomplete: 'new-password', class: 'form_field', required:'required'
       .actions
         //このコード分からなかったです
         /= f.submit (t 'users.registrations.new.sign_up'), class: 'submit-btn'
         = f.submit ('次へ'), class: 'submit-btn'
     //このコード分からなかったです
-    /= render "users/shared/links"
+    = render "users/shared/links"

--- a/app/views/users/shared/_links.html.slim
+++ b/app/views/users/shared/_links.html.slim
@@ -1,5 +1,5 @@
 - if controller_name != 'sessions'
-  = link_to t('users.sessions.new.sign_in'), new_session_path(resource_name)
+  div.login-btn = link_to t('users.sessions.new.sign_in'), new_session_path(resource_name)
   br
 - if devise_mapping.registerable? && controller_name != 'registrations'
   = link_to t('users.registrations.new.sign_up'), new_registration_path(resource_name)


### PR DESCRIPTION
- comon.scssの名前がスペルミスなためcommon.scssに変更した
_共通のを英語にするとcommonのため_

- headerのリンクのパスを指定した

- 会員登録画面の１ページ目の余白を修正した
_余白が大きく空いていて違和感を感じたため_

- 共通化できるものはcommon.scssに記述するようにした
_共通化してコード量を少なくしてどこに何があるかを把握しやすくした_

_Before_
<img width="1000" alt="スクリーンショット 2022-03-25 1 31 37" src="https://user-images.githubusercontent.com/85437356/160229206-d81092fe-efc5-46eb-953b-eed26988c1e6.png">

_After_
<img width="1000" alt="スクリーンショット 2022-03-26 16 15 15" src="https://user-images.githubusercontent.com/85437356/160229219-72d92540-bdf3-4ce7-bde8-141f35473798.png">

